### PR TITLE
Compressed parsing

### DIFF
--- a/surfaxe/analysis.py
+++ b/surfaxe/analysis.py
@@ -186,10 +186,10 @@ plt_fname='potential.png', **kwargs):
     # Read potential and structure data
     if os.path.exists(locpot):
         lpt = Locpot.from_file(locpot)
-        structure = lpt.structure
+        struc = lpt.structure
     elif os.path.exists(locpot + ".gz"):
         lpt = Locpot.from_file(locpot + ".gz")
-        structure = lpt.structure
+        struc = lpt.structure
     else:
         raise FileNotFoundError(
             f"""No LOCPOT(.gz) found at {locpot}(.gz)""")

--- a/surfaxe/analysis.py
+++ b/surfaxe/analysis.py
@@ -3,7 +3,8 @@ from pymatgen.core import Structure
 from pymatgen.analysis.local_env import CrystalNN, CutOffDictNN
 from pymatgen.io.vasp.outputs import Locpot
 
-# Misc 
+# Misc
+import os
 import math
 import numpy as np
 import pandas as pd
@@ -183,8 +184,15 @@ plt_fname='potential.png', **kwargs):
         DataFrame
     """
     # Read potential and structure data
-    lpt = Locpot.from_file(locpot)
-    struc = Structure.from_file(locpot)
+    if os.path.exists(locpot):
+        lpt = Locpot.from_file(locpot)
+        structure = lpt.structure
+    elif os.path.exists(locpot + ".gz"):
+        lpt = Locpot.from_file(locpot + ".gz")
+        structure = lpt.structure
+    else:
+        raise FileNotFoundError(
+            f"""No LOCPOT(.gz) found at {locpot}(.gz)""")
 
     # Planar potential
     planar = lpt.get_average_along_axis(2)

--- a/surfaxe/convergence.py
+++ b/surfaxe/convergence.py
@@ -141,8 +141,15 @@ csv_fname=None, verbose=False, **kwargs):
             otc_path = '{}/OUTCAR'.format(path)
 
             # instantiate structure, slab, vasprun and outcar objects
-            vsp = Vasprun(vsp_path, parse_potcar_file=False)
-            otc = Outcar(otc_path)
+            if os.path.exists(vsp_path):
+                vsp = Vasprun(vsp_path, parse_potcar_file=False)
+            elif os.path.exists(vsp_path + '.gz'):
+                vsp = Vasprun(vsp_path + '.gz', parse_potcar_file=False)
+            if os.path.exists(otc_path):
+                otc = Outcar(otc_path)
+            elif os.path.exists(otc_path + '.gz'):
+                otc = Outcar(otc_path + '.gz')
+
             slab = slab_from_file(vsp.final_structure, hkl)
             vsp_dict = vsp.as_dict()
 
@@ -379,8 +386,15 @@ vac_thickness, slab_index, core_atom=None, bulk_nn=None, **kwargs):
     # instantiate structure, slab, vasprun and outcar objects
     vsp_path = '{}/vasprun.xml'.format(path)
     otc_path = '{}/OUTCAR'.format(path)
-    vsp = Vasprun(vsp_path, parse_potcar_file=False)
-    otc = Outcar(otc_path)
+    if os.path.exists(vsp_path):
+        vsp = Vasprun(vsp_path, parse_potcar_file=False)
+    elif os.path.exists(vsp_path + '.gz'):
+        vsp = Vasprun(vsp_path + '.gz', parse_potcar_file=False)
+    if os.path.exists(otc_path):
+        otc = Outcar(otc_path)
+    elif os.path.exists(otc_path + '.gz'):
+        otc = Outcar(otc_path + '.gz')
+
     slab = slab_from_file(vsp.final_structure, hkl)
     vsp_dict = vsp.as_dict()
 

--- a/surfaxe/convergence.py
+++ b/surfaxe/convergence.py
@@ -115,9 +115,9 @@ csv_fname=None, verbose=False, **kwargs):
 
 
     # Check if multiple cores are available, iterate through paths to folders 
-    # and parse folders 
-    if multiprocessing.cpu_count() > 1: 
-        with multiprocessing.Pool() as pool: 
+    # and parse folders
+    if multiprocessing.cpu_count() > 1:
+        with multiprocessing.Pool() as pool:
             mp_list = pool.starmap(
                 functools.partial(_mp_helper_energy, parse_vacuum, 
                 get_core, hkl, core_atom=core_atom, bulk_nn=bulk_nn, 
@@ -134,7 +134,7 @@ csv_fname=None, verbose=False, **kwargs):
         gradient_list = list(itertools.chain.from_iterable(
             [i[3] for i in mp_list]))
     
-    else: 
+    else:
         df_list, electrostatic_list, core_energy_list, gradient_list = ([] for i in range(4))
         for path, slab_thickness, vac_thickness, slab_index in list_of_paths: 
             vsp_path = '{}/vasprun.xml'.format(path)
@@ -143,11 +143,11 @@ csv_fname=None, verbose=False, **kwargs):
             # instantiate structure, slab, vasprun and outcar objects
             if os.path.exists(vsp_path):
                 vsp = Vasprun(vsp_path, parse_potcar_file=False)
-            elif os.path.exists(vsp_path + '.gz'):
+            else:  # should give error if neither vasprun.xml(.gz) able to be parsed
                 vsp = Vasprun(vsp_path + '.gz', parse_potcar_file=False)
             if os.path.exists(otc_path):
                 otc = Outcar(otc_path)
-            elif os.path.exists(otc_path + '.gz'):
+            else:  # should give error if neither OUTCAR(.gz) able to be parsed
                 otc = Outcar(otc_path + '.gz')
 
             slab = slab_from_file(vsp.final_structure, hkl)
@@ -388,11 +388,11 @@ vac_thickness, slab_index, core_atom=None, bulk_nn=None, **kwargs):
     otc_path = '{}/OUTCAR'.format(path)
     if os.path.exists(vsp_path):
         vsp = Vasprun(vsp_path, parse_potcar_file=False)
-    elif os.path.exists(vsp_path + '.gz'):
+    else:  # should give error if neither vasprun.xml(.gz) able to be parsed
         vsp = Vasprun(vsp_path + '.gz', parse_potcar_file=False)
     if os.path.exists(otc_path):
         otc = Outcar(otc_path)
-    elif os.path.exists(otc_path + '.gz'):
+    else:  # should give error if neither OUTCAR(.gz) able to be parsed
         otc = Outcar(otc_path + '.gz')
 
     slab = slab_from_file(vsp.final_structure, hkl)

--- a/surfaxe/vasp_data.py
+++ b/surfaxe/vasp_data.py
@@ -119,7 +119,7 @@ save_csv=True, csv_fname='data.csv', **kwargs):
         vsp_path = '{}/vasprun.xml'.format(path)
         if os.path.exists(vsp_path):
             vsp = Vasprun(vsp_path, parse_potcar_file=False)
-        elif os.path.exists(vsp_path + '.gz'):
+        else:  # should give error if neither vasprun.xml(.gz) able to be parsed
             vsp = Vasprun(vsp_path + '.gz', parse_potcar_file=False)
 
         psc_path = '{}/POSCAR'.format(path)
@@ -318,7 +318,7 @@ nn_method=CrystalNN(), outcar='OUTCAR', structure='POSCAR'):
         # Read OUTCAR, get the core state energy
         if os.path.exists(outcar):
             otc = Outcar(outcar)
-        elif os.path.exists(outcar + '.gz'):
+        else:  # should give error if neither OUTCAR(.gz) able to be parsed
             otc = Outcar(outcar + '.gz')
 
         core_energy_dict = otc.read_core_state_eigen()


### PR DESCRIPTION
Add the ability to parse gzipped `LOCPOT`s, `OUTCAR`s and `vasprun.xml`s to save file space when doing convergence tests of big cells (as well as production run calcs with hybrid etc etc). Tested and all runs as expected on my local, and passes `surfaxe` tests