### PR TITLE
handling missing argument

### DIFF
--- a/surfaxe/io.py
+++ b/surfaxe/io.py
@@ -109,6 +109,7 @@ config_dict, fmt, name, **save_slabs_kwargs):
                 potcars = _check_psp_dir()
                 if potcars:
                     cd = _load_config_dict(config_dict)
+                    save_slabs_kwargs = {'user_potcar_functional' if k == 'potcar_functional' else k: v for k, v in save_slabs_kwargs.items()}
                     vis = DictSet(slab['slab'], cd, **save_slabs_kwargs)
                     vis.write_input(
                         r'{}/{}/{}_{}_{}'.format(bulk_name, 


### PR DESCRIPTION
All tests passing 
```
38 passed, 48 warnings in 140.34s (0:02:20)
```

This is a wonderfully maintained and written repository. I added a quick fix to my discussion #19  but am happy to turn it into a function to make it more general. 